### PR TITLE
Set CI to false to ignore warnings during build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,10 @@ jobs:
     - run: npm --prefix questionservice install
     - run: npm --prefix gatewayservice install
     - run: npm --prefix webapp install
-    - run: npm --prefix webapp run build
+    - name: Build webapp without CI warnings as errors
+      run: npm --prefix webapp run build
+      env:
+        CI: false
     - run: npm --prefix webapp run test:e2e
   docker-push-webapp:
     name: Push webapp Docker Image to GitHub Packages


### PR DESCRIPTION
Modified an environment variable so that warnings are not considered errors during release of the application.