### PR TITLE
Add mode to home and ranking

### DIFF
--- a/gatewayservice/gateway-service.js
+++ b/gatewayservice/gateway-service.js
@@ -28,15 +28,15 @@ if (fs.existsSync(openapiPath)) {
   // Disable the "Try it out" button
   const swaggerOptions = {
     swaggerOptions: {
-      supportedSubmitMethods: [] 
+      supportedSubmitMethods: []
     }
   };
-  
+
   // Serve the Swagger UI documentation at the '/api-doc' endpoint
   // This middleware serves the Swagger UI files and sets up the Swagger UI page
   // It takes the parsed Swagger document as input
   app.use('/api-doc', swaggerUi.serve, swaggerUi.setup(swaggerDocument, swaggerOptions));
-  
+
 } else {
   console.log("Not configuring OpenAPI. Configuration file not present.")
 }
@@ -133,7 +133,7 @@ app.get('/getRound', async (req, res) => {
     const { topics } = req.query;
 
     const roundResponse = await axios.get(questionServiceUrl + '/getRound', {
-      params:{topics: topics}
+      params: { topics: topics }
     });
 
     res.json(roundResponse.data);
@@ -160,15 +160,19 @@ app.post('/addgame', async (req, res) => {
   }
 });
 
-app.get('/userstats/user/:username', async (req, res) => {
+app.get('/userstats', async (req, res) => {
   try {
-    const statsResponse = await axios.get(userServiceUrl + '/userstats/user/' + req.params.username);
+    const { username, mode, topic } = req.query;
+
+    const statsResponse = await axios.get(userServiceUrl + '/userstats', {
+      params: { username, mode, topic }
+    });
+    
     res.json(statsResponse.data);
   } catch (error) {
     res.status(error.response.status).json({ error: error.response.data.error });
   }
 });
-
 
 app.get('/usercoins/:username', async (req, res) => {
   try {
@@ -179,29 +183,10 @@ app.get('/usercoins/:username', async (req, res) => {
   }
 });
 
-
 app.post('/updatecoins', async (req, res) => {
   try {
     const updateResponse = await axios.post(userServiceUrl + '/updatecoins', req.body);
     res.json(updateResponse.data);
-  } catch (error) {
-    res.status(error.response.status).json({ error: error.response.data.error });
-  }
-});
-
-app.get('/userstats/topic/:topic', async (req, res) => {
-  try {
-    const usersResponse = await axios.get(userServiceUrl + '/userstats/topic/' + req.params.topic);
-    res.json(usersResponse.data);
-  } catch (error) {
-    res.status(error.response.status).json({ error: error.response.data.error });
-  }
-});
-
-app.get('/userstats/:username/:topic', async (req, res) => {
-  try {
-    const statsResponse = await axios.get(userServiceUrl + '/userstats/' + req.params.username + '/' + req.params.topic);
-    res.json(statsResponse.data);
   } catch (error) {
     res.status(error.response.status).json({ error: error.response.data.error });
   }

--- a/gatewayservice/gateway-service.test.js
+++ b/gatewayservice/gateway-service.test.js
@@ -45,12 +45,8 @@ describe('Gateway Service', () => {
                 return Promise.resolve({ data: { accessToken: 'mockedToken' } });
             } else if (url.endsWith('/getTopics')) {
                 return Promise.resolve({ data: { modes: ['city', 'athlete'] } });
-            } else if (url.endsWith('/userstats/user/testuser')) {
-                return Promise.resolve({ data: { message: 'Fetched user statistics for user: testuser' } });
-            } else if (url.endsWith('/userstats/mode/flag')) {
-                return Promise.resolve({ data: { message: 'Fetched statistics for mode: flag' } });
-            } else if (url.endsWith('/userstats/testuser/flag')) {
-                return Promise.resolve({ data: { message: 'Fetched statistics for user testuser in mode flag' } });
+            } else if (url.endsWith('/userstats')) {
+                return Promise.resolve({ data: { message: 'Fetched statistics' } });
             }
         });
     });
@@ -292,28 +288,12 @@ describe('Gateway Service', () => {
         expect(response.body.error).toBe('User service error');
     });
 
-    // Test /userstats/user/:username endpoint
+    // Test /userstats endpoint
     it('should fetch user statistics for a specific user from the user service', async () => {
-        const response = await request(app).get('/userstats/user/testuser').set('Authorization', `Bearer ${token}`);
+        const response = await request(app).get('/userstats').set('Authorization', `Bearer ${token}`);
 
         expect(response.statusCode).toBe(200);
-        expect(response.body.message).toBe('Fetched user statistics for user: testuser');
-    });
-
-    // Test /userstats/mode/:mode endpoint
-    it('should fetch user statistics for a specific game mode from the user service', async () => {
-        const response = await request(app).get('/userstats/mode/flag').set('Authorization', `Bearer ${token}`);
-
-        expect(response.statusCode).toBe(200);
-        expect(response.body.message).toBe('Fetched statistics for mode: flag');
-    });
-
-    // Test /userstats/:username/:mode endpoint
-    it('should fetch user statistics for a specific user and game mode from the user service', async () => {
-        const response = await request(app).get('/userstats/testuser/flag').set('Authorization', `Bearer ${token}`);
-
-        expect(response.statusCode).toBe(200);
-        expect(response.body.message).toBe('Fetched statistics for user testuser in mode flag');
+        expect(response.body.message).toBe('Fetched statistics');
     });
 
     // Test /usercoins/:username endpoint

--- a/users/userservice/game-model.js
+++ b/users/userservice/game-model.js
@@ -13,6 +13,10 @@ const gameSchema = new mongoose.Schema({
       type: Number,
       required: true,
     },
+    gameMode: {
+        type: String,
+        required: true,
+    },
     gameTopic:{
         type: [String],
         required: true,

--- a/users/userservice/user-service.js
+++ b/users/userservice/user-service.js
@@ -86,7 +86,7 @@ app.post('/adduser', async (req, res) => {
 //Saves a completed game to the database and updates the user stats
 app.post('/addgame', async (req, res) => {
   try {
-    validateRequiredFields(req, ['username', 'questions']);
+    validateRequiredFields(req, ['username', 'mode', 'questions']);
 
     const MAX_GAMES = 100;
 
@@ -105,15 +105,16 @@ app.post('/addgame', async (req, res) => {
     const score = questions.reduce((acc, question) => acc + (question.isCorrect ? question.pointsIncrement : 0), 0);
     const correctRate = questions.reduce((acc, question) => acc + (question.isCorrect ? 1 : 0), 0) / questions.length;
     const gameTopic = [...new Set(questions.map(question => question.topic))];
+
     const newGame = new Game({
       username: req.body.username,
       score: score,
       correctRate: correctRate,
+      gameMode: req.body.mode,
       gameTopic: gameTopic,
     });
 
     await newGame.save();
-
     
     calculateUserStatistics(newGame, questions);
 
@@ -122,6 +123,63 @@ app.post('/addgame', async (req, res) => {
     res.status(400).json({ error: error.message });
   }
 });
+
+//Function only called when a new game is added
+async function calculateUserStatistics(newGame, questions) {
+  try {
+
+    for (const topic of [...newGame.gameTopic, "all"]) {
+      let score;
+      let correctRate;
+      // Calculate statistics for the current topic
+      if (topic === "all") {
+        // Get global statistics from the game
+        score = newGame.score;
+        correctRate = newGame.correctRate;
+      } else {
+        // Filter questions for the current topic
+        const topicQuestions = questions.filter(question => question.topic === topic);
+        
+        // Calculate partial statistics for the current topic
+        score = topicQuestions.reduce((acc, question) => acc + (question.isCorrect ? question.pointsIncrement : 0), 0);
+        correctRate = topicQuestions.reduce((acc, question) => acc + (question.isCorrect ? 1 : 0), 0) / topicQuestions.length;
+      }
+
+      // Find existing user statistics for the current topic
+      const userStats = await UserStatistics.findOne({ username: newGame.username, mode: newGame.gameMode, topic: topic });
+
+      if (!userStats) {
+        // Create a new user statistics entry if it doesn't exist
+        const newUserStats = new UserStatistics({
+          username: newGame.username,
+          topic: topic,
+          totalScore: score,
+          correctRate: correctRate,
+          totalGamesPlayed: 1,
+        });
+        await newUserStats.save();
+      } else {
+        // Update existing user statistics
+        await UserStatistics.findOneAndUpdate(
+          { username: newGame.username, topic: topic },
+          {
+            $inc: { totalGamesPlayed: 1 },
+            $set: {
+              totalScore: userStats.totalScore + score,
+              correctRate: calculateNewAvg(correctRate, userStats.totalGamesPlayed, userStats.correctRate),
+            },
+          }
+        );
+      }
+    }
+  } catch (error) {
+    console.log(error);
+  }
+}
+
+function calculateNewAvg(newRate, totalGamesPlayed, oldAvg) {
+  return (totalGamesPlayed * oldAvg + newRate) / (totalGamesPlayed + 1);
+}
 
 // Function to update user coins
 async function updateUserCoins(username, coinsToAdd) {
@@ -185,73 +243,6 @@ app.post('/updatecoins', async (req, res) => {
   }
 });
 
-
-//Function only called when a new game is added
-async function calculateUserStatistics(newGame, questions) {
-  try {
-
-    for (const topic of [...newGame.gameTopic, "all"]) {
-      let score;
-      let correctRate;
-      let questionsAnswered;
-      // Calculate statistics for the current topic
-      if (topic === "all") {
-        // Get global statistics from the game
-        score = newGame.score;
-        correctRate = newGame.correctRate;
-        questionsAnswered = questions.length;
-      } else {
-        // Filter questions for the current topic
-        const topicQuestions = questions.filter(question => question.topic === topic);
-        
-        // Calculate partial statistics for the current topic
-        score = topicQuestions.reduce((acc, question) => acc + (question.isCorrect ? question.pointsIncrement : 0), 0);
-        correctRate = topicQuestions.reduce((acc, question) => acc + (question.isCorrect ? 1 : 0), 0) / topicQuestions.length;
-        questionsAnswered = topicQuestions.length;
-      }
-
-
-      // Find existing user statistics for the current topic
-      const userStats = await UserStatistics.findOne({ username: newGame.username, topic: topic });
-
-      if (!userStats) {
-        // Create a new user statistics entry if it doesn't exist
-        const newUserStats = new UserStatistics({
-          username: newGame.username,
-          topic: topic,
-          totalScore: score,
-          correctRate: correctRate,
-          totalQuestions: questionsAnswered,
-          totalGamesPlayed: 1,
-        });
-        await newUserStats.save();
-      } else {
-        // Update existing user statistics
-        const oldTotalGamesPlayed = userStats.totalGamesPlayed;
-        const oldTotalScore = userStats.totalScore;
-        const oldCorrectRate = userStats.correctRate;
-
-        await UserStatistics.findOneAndUpdate(
-          { username: newGame.username, topic: topic },
-          {
-            $inc: { totalGamesPlayed: 1, totalQuestions: questionsAnswered },
-            $set: {
-              totalScore: oldTotalScore + score,
-              correctRate: calculateNewAvg(correctRate, oldTotalGamesPlayed, oldCorrectRate),
-            },
-          }
-        );
-      }
-    }
-  } catch (error) {
-    console.log(error);
-  }
-}
-
-function calculateNewAvg(newRate, totalGamesPlayed, oldAvg) {
-  return (totalGamesPlayed * oldAvg + newRate) / (totalGamesPlayed + 1);
-}
-
 // Find user statistics for a specific user
 app.get('/userstats/user/:username', async (req, res) => {
   try {
@@ -265,7 +256,6 @@ app.get('/userstats/user/:username', async (req, res) => {
   }
 });
 
-
 // Find user statistics for a specific topic
 app.get('/userstats/topic/:topic', async (req, res) => {
   try {
@@ -278,8 +268,6 @@ app.get('/userstats/topic/:topic', async (req, res) => {
     res.status(500).json({ error: error.message });
   }
 });
-
-
 
 // Find user statistics for a specific user and topic
 app.get('/userstats/:username/:topic', async (req, res) => {

--- a/users/userservice/user-service.js
+++ b/users/userservice/user-service.js
@@ -152,6 +152,7 @@ async function calculateUserStatistics(newGame, questions) {
         // Create a new user statistics entry if it doesn't exist
         const newUserStats = new UserStatistics({
           username: newGame.username,
+          mode: newGame.gameMode,
           topic: topic,
           totalScore: score,
           correctRate: correctRate,
@@ -161,7 +162,7 @@ async function calculateUserStatistics(newGame, questions) {
       } else {
         // Update existing user statistics
         await UserStatistics.findOneAndUpdate(
-          { username: newGame.username, topic: topic },
+          { username: newGame.username, mode: newGame.gameMode, topic: topic },
           {
             $inc: { totalGamesPlayed: 1 },
             $set: {

--- a/users/userservice/user-service.js
+++ b/users/userservice/user-service.js
@@ -182,6 +182,19 @@ function calculateNewAvg(newRate, totalGamesPlayed, oldAvg) {
   return (totalGamesPlayed * oldAvg + newRate) / (totalGamesPlayed + 1);
 }
 
+// Find user statistics for a specific user
+app.get('/userstats', async (req, res) => {
+  try {
+    const filter = { ...req.query };
+
+    const stats = await UserStatistics.find(filter);
+
+    res.json({ message: `Fetched statistics`, stats });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
 // Function to update user coins
 async function updateUserCoins(username, coinsToAdd) {
   try {
@@ -241,46 +254,6 @@ app.post('/updatecoins', async (req, res) => {
     });
   } catch (error) {
     res.status(400).json({ error: error.message });
-  }
-});
-
-// Find user statistics for a specific user
-app.get('/userstats/user/:username', async (req, res) => {
-  try {
-    const username = req.params.username;
-
-    const userStats = await UserStatistics.find({ username: username });
-
-    res.json({ message: `Fetched statistics for user: ${username}`, stats: userStats });
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-});
-
-// Find user statistics for a specific topic
-app.get('/userstats/topic/:topic', async (req, res) => {
-  try {
-    const topic = req.params.topic;
-
-    const userStats = await UserStatistics.find({ topic: topic });
-
-    res.json({ message: `Fetched statistics for topic: ${topic}`, stats: userStats });
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-});
-
-// Find user statistics for a specific user and topic
-app.get('/userstats/:username/:topic', async (req, res) => {
-  try {
-    const username = req.params.username;
-    const topic = req.params.topic;
-
-    const userStats = await UserStatistics.findOne({ username: username, topic: topic });
-
-    res.json({ message: `Fetched statistics for user ${username} in topic ${topic}`, stats: userStats });
-  } catch (error) {
-    res.status(500).json({ error: error.message });
   }
 });
 

--- a/users/userservice/user-service.test.js
+++ b/users/userservice/user-service.test.js
@@ -117,7 +117,7 @@ describe('User Service', () => {
     it('should add a new game on POST /addgame and update user statistics', async () => {
       const newGameData = {
         username: 'GameUser1',
-        password: 'GameUser1!',
+        mode: 'rounds',
         questions: [
           { topic: 'arcade', isCorrect: true, pointsIncrement: 50 },
           { topic: 'arcade', isCorrect: false, pointsIncrement: 50 },
@@ -147,6 +147,7 @@ describe('User Service', () => {
           score: i,
           correctRate: 0.5,
           gameTopic: 'classic',
+          gameMode: 'rounds',
           createdAt: new Date(Date.now() - 1000 * (MAX_GAMES - i))
         }).save();
       }
@@ -156,12 +157,11 @@ describe('User Service', () => {
 
       const newGameData = {
         username: 'GameUser1',
-        password: 'GameUser1!',
+        mode: 'rounds',
         questions: [
           { topic: 'classic', isCorrect: true, pointsIncrement: 50 },
           { topic: 'classic', isCorrect: false, pointsIncrement: 50 },
         ],
-        createdAt: Date.now(), // Set createdAt to the current date
       };
 
       const response = await request(app).post('/addgame').send(newGameData);
@@ -176,16 +176,14 @@ describe('User Service', () => {
   });
 
   describe('User Statistics endpoint', () => {
-    async function addGameData(username, password, questions) {
-      await request(app).post('/addgame').send({ username, password, questions });
+    async function addGameData(username, mode, questions) {
+      await request(app).post('/addgame').send({ username, mode, questions });
     }
 
     beforeAll(async () => {
-
       // Clear previous data
       await UserStatistics.deleteMany({});
       await Game.deleteMany({});
-
 
       // Create users with valid credentials
       const statsUser = { username: 'StatsUser1', password: 'StatsPass1!' };
@@ -199,85 +197,50 @@ describe('User Service', () => {
       await request(app).post('/adduser').send(allUser);
 
       // Add game data for testing
-      await addGameData('StatsUser1', 'StatsPass1!', [{ topic: 'arcade', isCorrect: true, pointsIncrement: 70 }]);
-      await addGameData('StatsUser1', 'StatsPass1!', [{ topic: 'arcade', isCorrect: false, pointsIncrement: 80 }]);
+      await addGameData('user1', 'rounds', [{ topic: 'arcade', isCorrect: true, pointsIncrement: 70 }]);
+      await addGameData('user1', 'rounds', [{ topic: 'arcade', isCorrect: false, pointsIncrement: 80 }]);
 
-      await addGameData('User1Test', 'Password1!', [{ topic: 'flag', isCorrect: true, pointsIncrement: 70 }]);
-      await addGameData('User1Test', 'Password1!', [{ topic: 'flag', isCorrect: false, pointsIncrement: 50 }]);
-      await addGameData('User2Test', 'Password2!', [{ topic: 'flag', isCorrect: true, pointsIncrement: 80 }]);
+      await addGameData('user1', 'time', [{ topic: 'flag', isCorrect: true, pointsIncrement: 70 }]);
+      await addGameData('user1', 'time', [{ topic: 'flag', isCorrect: false, pointsIncrement: 50 }]);
+      await addGameData('user1', 'time', [{ topic: 'flag', isCorrect: true, pointsIncrement: 80 }]);
 
-      await addGameData('User1Test', 'Password1!', [{ topic: 'arcade', isCorrect: true, pointsIncrement: 100 }]);
-      await addGameData('User1Test', 'Password1!', [{ topic: 'arcade', isCorrect: false, pointsIncrement: 50 }]);
-      await addGameData('User2Test', 'Password2!', [{ topic: 'arcade', isCorrect: true, pointsIncrement: 90 }]);
+      await addGameData('user1', 'hide', [{ topic: 'arcade', isCorrect: true, pointsIncrement: 100 }]);
+      await addGameData('user1', 'hide', [{ topic: 'arcade', isCorrect: false, pointsIncrement: 50 }]);
+      await addGameData('user1', 'hide', [{ topic: 'sports', isCorrect: true, pointsIncrement: 90 }]);
 
-      await addGameData('AllUserTest', 'Password3!', [{ topic: 'arcade', isCorrect: true, pointsIncrement: 100 }]);
-      await addGameData('AllUserTest', 'Password3!', [{ topic: 'flag', isCorrect: false, pointsIncrement: 50 }]);
-      await addGameData('AllUserTest', 'Password3!', [{ topic: 'arcade', isCorrect: true, pointsIncrement: 90 }]);
+      await addGameData('user2', 'rounds', [{ topic: 'arcade', isCorrect: true, pointsIncrement: 100 }]);
+      await addGameData('user2', 'rounds', [{ topic: 'flag', isCorrect: false, pointsIncrement: 50 }]);
+      await addGameData('user2', 'rounds', [{ topic: 'sports', isCorrect: true, pointsIncrement: 90 }]);
     });
 
-    it('should return user statistics on GET /userstats/user/:username', async () => {
-
-      const response = await request(app).get('/userstats/user/StatsUser1');
-      expect(response.status).toBe(200);
-
-      expect(Array.isArray(response.body.stats)).toBe(true);
-      expect(response.body.stats.length).toBeGreaterThan(0);
-      
-      const stats = response.body.stats[0];
-      expect(stats.username).toBe('StatsUser1');
-      expect(stats.totalScore).toBe(70); // Only the correct answer adds points
-      expect(stats.correctRate).toBe(0.5); // 1 correct, 1 incorrect = 0.5
-      expect(stats.totalGamesPlayed).toBe(2);
-    });
-
-    it('should return empty array if user statistics not found on GET /userstats/user/:username', async () => {
-      const response = await request(app).get('/userstats/user/nonexistentuser');
+    it('should return empty array if user statistics not found on GET /userstats', async () => {
+      const response = await request(app).get('/userstats?username=nonexistentuser');
       expect(response.status).toBe(200);
       expect(response.body.stats).toEqual([]);
     });
 
-    it('should return all statistics for a specific game topic on GET /userstats/topic/:topic', async () => {
-      const response = await request(app).get('/userstats/topic/flag');
+    it('should return stats corresponding to the filter on GET /userstats', async () => {
+      // Get all user statistics
+      let response = await request(app).get('/userstats?mode=rounds&topic=arcade');
       expect(response.status).toBe(200);
-      
+
       // Check array length and sort order
       expect(response.body.stats.length).toBeGreaterThanOrEqual(2);
-      
+
       // Find the users in the results (order might vary)
-      const user1Stats = response.body.stats.find(s => s.username === 'User1Test');
-      const user2Stats = response.body.stats.find(s => s.username === 'User2Test');
+      const user1Stats = response.body.stats.find(s => s.username === 'user1');
+      const user2Stats = response.body.stats.find(s => s.username === 'user2');
       
       expect(user1Stats).toBeDefined();
       expect(user2Stats).toBeDefined();
       
       expect(user1Stats.totalScore).toBe(70);
-      expect(user2Stats.totalScore).toBe(80);
+      expect(user2Stats.totalScore).toBe(100);
       expect(user1Stats.correctRate).toBe(0.5);
       expect(user2Stats.correctRate).toBe(1);
       expect(user1Stats.totalGamesPlayed).toBe(2);
       expect(user2Stats.totalGamesPlayed).toBe(1);
     });
-
-    it('should return all statistics for a specific user and topic on GET /userstats/:username/:topic', async () => {
-      const response = await request(app).get('/userstats/User1Test/arcade');
-      expect(response.status).toBe(200);
-      expect(response.body.stats.username).toBe('User1Test');
-      expect(response.body.stats.totalScore).toBe(100);
-      expect(response.body.stats.correctRate).toBe(0.5);
-      expect(response.body.stats.totalGamesPlayed).toBe(2);
-    });
-
-    it('should return the combined statistics for all game topics on GET /userstats/:username/all', async () => {
-       const response = await request(app).get('/userstats/AllUserTest/all');
-      expect(response.status).toBe(200);
-      expect(response.body.stats.username).toBe('AllUserTest');
-      expect(response.body.stats.totalScore).toBe(190); // 100 + 0 + 90
-      
-      // Weighted average: (1*1 + 0*1 + 1*1)/3 = 2/3
-      expect(response.body.stats.correctRate).toBeCloseTo(2/3, 5);
-      expect(response.body.stats.totalGamesPlayed).toBe(3);
-    });
-
   }); 
 },
 
@@ -429,6 +392,7 @@ describe('Game Management', () => {
     // First add some games
     const gameData = {
       username: 'GameTestUser',
+      mode: 'rounds',
       questions: [
         { topic: 'arcade', isCorrect: true, pointsIncrement: 50 },
         { topic: 'flag', isCorrect: false, pointsIncrement: 30 }
@@ -456,7 +420,8 @@ describe('Game Management', () => {
   
   it('should handle error when adding game with missing required fields', async () => {
     const invalidGameData = {
-      username: 'GameTestUser'
+      username: 'GameTestUser',
+      mode: 'rounds',
       // Missing 'questions' field
     };
     
@@ -485,6 +450,7 @@ describe('Game Management', () => {
   // Add a game with multiple topics to test statistics creation
   const gameData = {
     username: 'StatsTestUser',
+    mode: 'rounds',
     questions: [
       { topic: 'newTopic', isCorrect: true, pointsIncrement: 100 }
     ]

--- a/users/userservice/user-statistic-model.js
+++ b/users/userservice/user-statistic-model.js
@@ -17,10 +17,6 @@ const userStatisticSchema = new mongoose.Schema({
     type: Number,
     default: 0,
   },
-  totalQuestions: {
-    type: Number,
-    default: 0,
-  },
   totalGamesPlayed: {
     type: Number,
     default: 0,

--- a/users/userservice/user-statistic-model.js
+++ b/users/userservice/user-statistic-model.js
@@ -5,6 +5,10 @@ const userStatisticSchema = new mongoose.Schema({
     type: String,
     required: true,
   },
+  mode: {
+    type: String,
+    required: true,
+  },
   topic: {
     type: String,
     required: true,
@@ -23,7 +27,7 @@ const userStatisticSchema = new mongoose.Schema({
   },
 });
 
-userStatisticSchema.index({ username: 1, topic: 1 }, { unique: true });
+userStatisticSchema.index({ username: 1, mode: 1, topic: 1 }, { unique: true });
 
 const UserStatistics = mongoose.model('UserStatistic', userStatisticSchema);
 

--- a/webapp/src/components/Home.js
+++ b/webapp/src/components/Home.js
@@ -13,7 +13,7 @@ const Home = () => {
     const { theme } = useTheme();
 
     const [activeMainTab, setactiveMainTab] = useState(0);
-    const [activeModeTab, setActiveModeTab] = useState(0);
+    const [activeModeTab, setActiveModeTab] = useState("rounds");
     const [mode, setMode] = useState("rounds");
     const [gametopic, setGameTopic] = useState("all");
     const [gametopics, setGameTopics] = useState(["all"]);
@@ -39,7 +39,6 @@ const Home = () => {
         // Get recent games
         axios.get(`/games/${auth.username}`)
             .then((res) => {
-                console.log(res.data.games);
                 setGames(res.data.games.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt)));
             }).catch((err) => {
                 console.error("Error fetching games:", err);

--- a/webapp/src/components/Home.js
+++ b/webapp/src/components/Home.js
@@ -150,7 +150,7 @@ const Home = () => {
                 {/* Statistics tab */}
                 <Box hidden={activeMainTab !== 0} mb={4}>
                     {/* User statistics */}
-                    <CardHeader title={`Your Stats for ${mode.charAt(0).toUpperCase() + mode.slice(1)}`} sx={{ p: 0, my: 2 }} />
+                    <CardHeader title={`Your statistics for ${mode.charAt(0).toUpperCase() + mode.slice(1)}`} sx={{ p: 0, my: 2 }} />
                     {userStats?.username ? (
                         <Grid2 container spacing={2}>
                             <Grid2 size={4} sx={{ display: "flex", alignItems: "center", gap: 2, p: 4, borderRadius: 2, bgcolor: "background.paper", border: 1, borderColor: "divider" }}>
@@ -176,7 +176,7 @@ const Home = () => {
                             </Grid2>
                         </Grid2>
                     ) : (
-                        <Typography variant="body1" color="text.secondary">No statistics found.</Typography>
+                        <Typography variant="body1" color="text.secondary">No statistics found for this mode.</Typography>
                     )}
 
                     {/* Recent games */}

--- a/webapp/src/components/Home.js
+++ b/webapp/src/components/Home.js
@@ -26,6 +26,7 @@ const Home = () => {
         // Clear selected topics after finishing the game and navigating back to the home page
         sessionStorage.removeItem("selectedTopics");
 
+        // Get user statistics
         axios.get(`/userstats/${auth.username}/all`)
             .then((res) => {
                 setUserStats(res.data.stats);
@@ -33,6 +34,7 @@ const Home = () => {
                 console.error("Error fetching user stats:", err);
             });
 
+        // Get game topics
         axios.get("/getTopics")
             .then((res) => {
                 setGameTopics(["all", ...res.data.topics]);
@@ -40,14 +42,17 @@ const Home = () => {
                 console.error("Error fetching gametopics:", err);
             });
 
+        // Get recent games
         axios.get(`/games/${auth.username}`)
             .then((res) => {
+                console.log(res.data.games);
                 setGames(res.data.games.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt)));
             }).catch((err) => {
                 console.error("Error fetching games:", err);
             });
     }, []);
 
+    // Get all user statistics for the selected game topic and stat
     useEffect(() => {
         axios.get(`/userstats/topic/${gametopic}`)
             .then((res) => {
@@ -175,7 +180,7 @@ const Home = () => {
                                         {getIconForTopics(game.gameTopic)}
                                         <Box>
                                             <Typography variant="body1" fontWeight="bold">
-                                                GAMEMODE - Topics: {game.gameTopic.join(", ")}
+                                                {game.gameMode.toUpperCase()} - Topics: {game.gameTopic.join(", ")}
                                             </Typography>
                                             <Typography variant="body2" color="text.secondary">
                                                 Played on {new Date(game.createdAt).toLocaleDateString("es")}

--- a/webapp/src/components/Home.js
+++ b/webapp/src/components/Home.js
@@ -151,7 +151,7 @@ const Home = () => {
                 {/* Statistics tab */}
                 <Box hidden={activeMainTab !== 0} mb={4}>
                     {/* User statistics */}
-                    <CardHeader title="Your Statistics" sx={{ p: 0, my: 2 }} />
+                    <CardHeader title={`Your Stats for ${mode.charAt(0).toUpperCase() + mode.slice(1)}`} sx={{ p: 0, my: 2 }} />
                     {userStats?.username ? (
                         <Grid2 container spacing={2}>
                             <Grid2 size={4} sx={{ display: "flex", alignItems: "center", gap: 2, p: 4, borderRadius: 2, bgcolor: "background.paper", border: 1, borderColor: "divider" }}>
@@ -225,7 +225,7 @@ const Home = () => {
                 {/* Rankings tab */}
                 <Box hidden={activeMainTab !== 1} mb={4}>
                     <Box sx={{ display: "grid", gridTemplateColumns: "1fr auto 1fr", alignItems: "center", width: "100%" }}>
-                        <CardHeader title="Leaderboard" subheader={`Top players ranked by ${stat}`} />
+                        <CardHeader title={`${mode.charAt(0).toUpperCase() + mode.slice(1)} Leaderboard`} subheader={`Top players ranked by ${stat}`} />
                         <Box sx={{ p: 2, display: "flex", flexDirection: "column", alignItems: "center" }}>
                             <Typography variant="subtitle1" sx={{ color: "text.secondary" }}>
                                 Rank by:

--- a/webapp/src/components/Home.test.js
+++ b/webapp/src/components/Home.test.js
@@ -92,19 +92,9 @@ describe("Home component", () => {
   });
 
   it("should fetch and display user stats", async () => {
-    const mockStats = {
-      stats: [{
-        username: "otheruser",
-        totalScore: 1000,
-        correctRate: 0.9,
-        totalQuestions: 200,
-        totalGamesPlayed: 20
-      }]
-    };
-  
     // Mock the API responses
     mockAxios.onGet("/getTopics").reply(200, { topics: ["history", "science"] });
-    mockAxios.onGet("/userstats/testuser/all").reply(200, { 
+    mockAxios.onGet("/userstats?username=testuser&mode=rounds&topic=all").reply(200, { 
       stats: {
         username: "testuser",
         totalScore: 800,
@@ -112,12 +102,11 @@ describe("Home component", () => {
         totalGamesPlayed: 15
       }
     });
-    mockAxios.onGet("/userstats/topic/all").reply(200, { 
+    mockAxios.onGet("/userstats?topic=all&mode=rounds").reply(200, { 
       stats: [{
         username: "otheruser",
         totalScore: 1000,
         correctRate: 0.9,
-        totalQuestions: 200,
         totalGamesPlayed: 20
       }]
     });

--- a/webapp/src/components/game/BaseGame.js
+++ b/webapp/src/components/game/BaseGame.js
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { useNavigate } from "react-router";
 import { Toolbar, Typography, Button, Card, CardContent, Grid, Box, Dialog, DialogActions, DialogContent, DialogTitle, CircularProgress, Container } from "@mui/material";
 import { HelpOutline, Phone, Chat, InterpreterMode, EmojiEvents, MonetizationOn } from "@mui/icons-material";
@@ -20,7 +20,7 @@ const BaseGame = React.forwardRef(({
   children,
   onNewGame = () => { },
   onRoundComplete = () => { },
-  gameEnding = () => false,
+  isGameOver = false,
   mode = "rounds",
 }, ref) => {
   const axios = useAxios();
@@ -33,33 +33,37 @@ const BaseGame = React.forwardRef(({
   const [loading, setLoading] = useState(true);
   const [chatKey, setChatKey] = useState(0); // resets the chat component every time it is updated
   const [showStatistics, setShowStatistics] = useState(false);
-  const [_, setQuestions] = useState([]);
+  const [questions, setQuestions] = useState([]);
   const [correctAnswers, setCorrectAnswers] = useState(0);
   const [roundsPlayed, setRoundsPlayed] = useState(0);
+
+  const answerTimer = useRef(null); // Holds the timer for the answer selection
 
   const { coins, spentCoins, setSpentCoins, canAfford, spendCoins, fetchUserCoins, updateUserCoins } = useCoinHandler(axios, auth);
   const { handleFiftyFifty, handleCallFriend, handleCloseCallFriend, handleAudienceCall, handlePhoneOut, handlePhoneOutClose, handleUseChat,
     hiddenOptions, isTrue, setHiddenOptions, setShowGraph, newGame } = useLifeLinesHandler(roundData, spendCoins);
 
-  // Set up the game when the component mounts
+  // Load rounds every time the roundsPlayed changes and on start up
   useEffect(() => {
-    gameSetup();
-  }, []);
+    if (!isGameOver) {
+      const load = async () => {
+        setRoundData(null);
+        try {
+          const data = await loadRound();
+          setRoundData(data);
+        } catch (error) {
+          console.error("Error loading new round", error);
+          setLoading(false);
+        }
+      }
+
+      load();
+    }
+  }, [roundsPlayed, isGameOver]);
 
   useEffect(() => {
     fetchUserCoins();
   }, [auth]);
-
-  const gameSetup = async () => {
-    try {
-      // First round
-      const data = await loadRound()
-      setRoundData(data)
-    } catch (error) {
-      console.error("Error fetching data from question service:", error)
-      setLoading(false)
-    }
-  }
 
   // Function to load the data for each round.
   const loadRound = async () => {
@@ -101,7 +105,7 @@ const BaseGame = React.forwardRef(({
   useEffect(() => {
     let intervalId;
 
-    if (loading) {
+    if (loading && !isGameOver) {
       intervalId = setInterval(async () => {
         try {
           const data = await loadRound();
@@ -122,20 +126,30 @@ const BaseGame = React.forwardRef(({
   }, [loading]);
 
   // Add the game statistics to the database and show the statistics dialog
-  const endGame = async (questions) => {
-    try {
-      // Calculate earned coins based on score
-      const earnedCoins = Math.round(score * 0.3);
-      await updateUserCoins(earnedCoins);
-      await axios.post("/addgame", { username: auth.username, mode, questions });
-    } catch (error) {
-      console.error("Error saving user stadistics:", error);
-    }
+  useEffect(() => {
+    if (isGameOver) {
+      const endGame = async () => {
+        try {
+          // Calculate earned coins based on score
+          const earnedCoins = Math.round(score * 0.3);
+          await updateUserCoins(earnedCoins);
+          await axios.post("/addgame", { username: auth.username, mode, questions });
+        } catch (error) {
+          console.error("Error saving user stadistics:", error);
+        }
 
-    setShowStatistics(true);
-  };
+        setShowStatistics(true);
+      };
+
+      endGame();
+    }
+  }, [isGameOver]);
 
   const handleNewGame = async () => {
+    // Mode specific setup
+    onNewGame();
+
+    // General setup
     setShowStatistics(false);
     setRoundData(null);
     setScore(0);
@@ -146,15 +160,10 @@ const BaseGame = React.forwardRef(({
     setQuestions([]);
     setCorrectAnswers(0);
     setRoundsPlayed(0);
-
-    // Mode specific setup
-    onNewGame();
-
-    gameSetup();
   };
 
   const handleOptionSelect = async (index) => {
-    setRoundsPlayed(roundsPlayed + 1);
+    if (isGameOver || selectedAnswer !== null) return; // Prevent multiple selections
 
     const isCorrect = correctOption(index);
     setSelectedAnswer(index);
@@ -166,38 +175,41 @@ const BaseGame = React.forwardRef(({
       setShowGraph(false);
     }
 
-    let updatedQuestions = [];
-    setQuestions((prev) => {
-      updatedQuestions = [
-        ...prev,
-        {
-          topic: roundData.topic,
-          isCorrect: isCorrect,
-          pointsIncrement: pointsIncrement,
-        },
-      ];
-      return updatedQuestions;
-    });
+    setQuestions((prev) => [
+      ...prev,
+      {
+        topic: roundData.topic,
+        isCorrect: isCorrect,
+        pointsIncrement: pointsIncrement,
+      },
+    ]);
 
-    setTimeout(async () => {
-      // Mode specific end condition
-      if (gameEnding()) {
-        return await endGame(updatedQuestions);
-      }
+    answerTimer.current = setTimeout(() => {
+      triggerNewRound(); // Trigger the next round after 2 seconds
 
-      // Mode specific round complete
-      onRoundComplete();
-      setRoundData(null);
-      setSelectedAnswer(null);
-
-      try {
-        const data = await loadRound();
-        setRoundData(data);
-      } catch (error) {
-        console.error("Error loading new round", error);
-        setLoading(false);
-      }
+      answerTimer.current = null; // Clear the timer reference
     }, 2000);
+
+    console.log("timer set", answerTimer.current)
+  }
+
+  useEffect(() => {
+    console.log("isGameOver", isGameOver, answerTimer.current)
+    if (isGameOver && answerTimer.current) {
+      console.log("Clearing timer", answerTimer.current)
+      clearTimeout(answerTimer.current); // Clear the timer when the game is over
+      answerTimer.current = null; // Reset the timer reference
+
+      triggerNewRound(); // Trigger the next round immediately
+    }
+  }, [isGameOver]);
+
+  const triggerNewRound = () => {
+    setRoundsPlayed(roundsPlayed + 1);
+    setSelectedAnswer(null);
+
+    // Mode specific round complete
+    onRoundComplete();
   }
 
   const correctOption = (index) => {
@@ -336,7 +348,7 @@ const BaseGame = React.forwardRef(({
               ) : (
                 roundData && (
                   <>
-                    {typeof children === 'function' ? children({ endGame, handleOptionSelect }) : children}
+                    {typeof children === 'function' ? children({ handleOptionSelect }) : children}
                     <ImageContainer>
                       <img
                         ref={ref}

--- a/webapp/src/components/game/BaseGame.js
+++ b/webapp/src/components/game/BaseGame.js
@@ -104,8 +104,6 @@ const BaseGame = React.forwardRef(({
   // Check if the game is still loading after modifying the round data
   useEffect(() => {
     if (roundData && roundData.items.length > 0) {
-      //const questionInfo = TOPIC_QUESTION_MAP[roundData.topic] || { wh: "What", name: roundData.topic }; // Value by default if topic is not found
-      //setRoundPrompt(`${questionInfo.wh} is this ${questionInfo.name}?`);
       setLoading(false);
     } else {
       setLoading(true);

--- a/webapp/src/components/game/BaseGame.js
+++ b/webapp/src/components/game/BaseGame.js
@@ -21,6 +21,7 @@ const BaseGame = React.forwardRef(({
   onNewGame = () => { },
   onRoundComplete = () => { },
   gameEnding = () => false,
+  mode = "rounds",
 }, ref) => {
   const axios = useAxios();
   const { auth } = useAuth();
@@ -32,7 +33,7 @@ const BaseGame = React.forwardRef(({
   const [loading, setLoading] = useState(true);
   const [chatKey, setChatKey] = useState(0); // resets the chat component every time it is updated
   const [showStatistics, setShowStatistics] = useState(false);
-  const [questions, setQuestions] = useState([]);
+  const [_, setQuestions] = useState([]);
   const [correctAnswers, setCorrectAnswers] = useState(0);
   const [roundsPlayed, setRoundsPlayed] = useState(0);
 
@@ -126,7 +127,7 @@ const BaseGame = React.forwardRef(({
       // Calculate earned coins based on score
       const earnedCoins = Math.round(score * 0.3);
       await updateUserCoins(earnedCoins);
-      await axios.post("/addgame", { username: auth.username, questions });
+      await axios.post("/addgame", { username: auth.username, mode, questions });
     } catch (error) {
       console.error("Error saving user stadistics:", error);
     }

--- a/webapp/src/components/game/BaseGame.test.js
+++ b/webapp/src/components/game/BaseGame.test.js
@@ -3,10 +3,9 @@ import { render, fireEvent, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
-import RoundsGame from "./RoundsGame";
 import useAxios from "../../hooks/useAxios";
 import { ThemeProvider } from "../../context/ThemeContext";
-import BaseGame from "./BaseGameLayout";
+import BaseGame from "./BaseGame";
 
 // Global mock for Material UI icons
 jest.mock("@mui/icons-material", () => {

--- a/webapp/src/components/game/HideGame.js
+++ b/webapp/src/components/game/HideGame.js
@@ -56,7 +56,7 @@ function HideGame() {
   }, [blur]);
 
   return (
-    <BaseGame onNewGame={onNewGame} onRoundComplete={onRoundComplete} gameEnding={() => round === totalRounds} ref={imageRef}>
+    <BaseGame mode="hide" onNewGame={onNewGame} onRoundComplete={onRoundComplete} gameEnding={() => round === totalRounds} ref={imageRef}>
       {({ handleOptionSelect }) => {
         handleOptionSelectRef.current = handleOptionSelect;
 

--- a/webapp/src/components/game/HideGame.js
+++ b/webapp/src/components/game/HideGame.js
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { alpha, LinearProgress, Typography } from "@mui/material";
-import BaseGame from "./BaseGameLayout";
+import BaseGame from "./BaseGame";
 import useTheme from "../../hooks/useTheme";
 
 function HideGame() {
@@ -34,6 +34,8 @@ function HideGame() {
   }
 
   useEffect(() => {
+    if (round === totalRounds + 1) return; // No need to set up the timer if the game is over
+
     const startTime = Date.now();
     const interval = setInterval(() => {
       const elapsedTime = (Date.now() - startTime) / 1000;
@@ -56,14 +58,14 @@ function HideGame() {
   }, [blur]);
 
   return (
-    <BaseGame mode="hide" onNewGame={onNewGame} onRoundComplete={onRoundComplete} gameEnding={() => round === totalRounds} ref={imageRef}>
+    <BaseGame mode="hide" onNewGame={onNewGame} onRoundComplete={onRoundComplete} isGameOver={round === totalRounds + 1} ref={imageRef}>
       {({ handleOptionSelect }) => {
         handleOptionSelectRef.current = handleOptionSelect;
 
         return (
           <>
             <Typography variant="h4" component="h2" align="center" gutterBottom color="primary" sx={{ fontWeight: "bold" }}>
-              Round {round}/{totalRounds}
+              Round {Math.min(round, totalRounds)}/{totalRounds}
             </Typography>
             <LinearProgress
               variant="determinate"

--- a/webapp/src/components/game/RoundsGame.js
+++ b/webapp/src/components/game/RoundsGame.js
@@ -2,16 +2,16 @@
 
 import { useState } from "react";
 import { Typography } from "@mui/material";
-import BaseGame from "./BaseGameLayout";
+import BaseGame from "./BaseGame";
 
 function RoundsGame() {
-  const totalRounds = 10;
+  const totalRounds = 5;
   const [round, setRound] = useState(1);
 
   return (
-    <BaseGame onNewGame={() => setRound(1)} onRoundComplete={() => setRound(round + 1)} gameEnding={() => round === totalRounds}>
+    <BaseGame onNewGame={() => setRound(1)} onRoundComplete={() => setRound(prev => prev + 1)} isGameOver={round === totalRounds + 1}>
       <Typography variant="h4" component="h2" align="center" gutterBottom color="primary" sx={{ fontWeight: "bold" }}>
-        Round {round}/{totalRounds}
+        Round {Math.min(round, totalRounds)}/{totalRounds}
       </Typography>
     </BaseGame>
   )

--- a/webapp/src/components/game/TimeGame.js
+++ b/webapp/src/components/game/TimeGame.js
@@ -1,14 +1,13 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import { Typography, Box, LinearProgress } from "@mui/material"
-import BaseGame from "./BaseGameLayout"
+import BaseGame from "./BaseGame"
 
 function TimeGame() {
   const TIME = 60;
   const [timeLeft, setTimeLeft] = useState(TIME);
   const [gameEnded, setGameEnded] = useState(false);
-  const endGameRef = useRef(null);
 
   const onNewGame = () => {
     setTimeLeft(TIME);
@@ -28,7 +27,6 @@ function TimeGame() {
       if (remainingTime <= 0) {
         clearInterval(interval);
         setGameEnded(true);
-        endGameRef.current();
       }
     }, 100);
 
@@ -36,33 +34,27 @@ function TimeGame() {
   }, [gameEnded]);
 
   return (
-    <BaseGame mode="time" onNewGame={onNewGame}>
-      {({ endGame }) => {
-        endGameRef.current = endGame;
-
-        return (
-          <Box sx={{ width: "100%", mb: 3 }}>
-            <Box sx={{ display: "flex", justifyContent: "space-between", mb: 1 }}>
-              <Typography variant="h6" fontWeight="bold" color="primary">
-                Time remaining: {timeLeft.toFixed(0)}s
-              </Typography>
-            </Box>
-            <LinearProgress
-              variant="determinate"
-              value={(timeLeft / TIME) * 100}
-              sx={{
-                height: 20,
-                borderRadius: 5,
-                backgroundColor: "rgba(0, 0, 0, 0.1)",
-                "& .MuiLinearProgress-bar": {
-                  borderRadius: 5,
-                  backgroundColor: timeLeft > 30 ? "success.main" : timeLeft > 10 ? "warning.main" : "error.main",
-                },
-              }}
-            />
-          </Box>
-        );
-      }}
+    <BaseGame mode="time" onNewGame={onNewGame} isGameOver={gameEnded}>
+      <Box sx={{ width: "100%", mb: 3 }}>
+        <Box sx={{ display: "flex", justifyContent: "space-between", mb: 1 }}>
+          <Typography variant="h6" fontWeight="bold" color="primary">
+            Time remaining: {timeLeft.toFixed(0)}s
+          </Typography>
+        </Box>
+        <LinearProgress
+          variant="determinate"
+          value={(timeLeft / TIME) * 100}
+          sx={{
+            height: 20,
+            borderRadius: 5,
+            backgroundColor: "rgba(0, 0, 0, 0.1)",
+            "& .MuiLinearProgress-bar": {
+              borderRadius: 5,
+              backgroundColor: timeLeft > 30 ? "success.main" : timeLeft > 10 ? "warning.main" : "error.main",
+            },
+          }}
+        />
+      </Box>
     </BaseGame>
   )
 }

--- a/webapp/src/components/game/TimeGame.js
+++ b/webapp/src/components/game/TimeGame.js
@@ -36,7 +36,7 @@ function TimeGame() {
   }, [gameEnded]);
 
   return (
-    <BaseGame onNewGame={onNewGame}>
+    <BaseGame mode="time" onNewGame={onNewGame}>
       {({ endGame }) => {
         endGameRef.current = endGame;
 


### PR DESCRIPTION
In the process I found some bugs in the different modes of game, so most of the changes were to fix those. More details on issue #181.

To add modes to the games, I modified slightly the game-model and added the necessary parameters to the /addgame endpoint. 

Then, I modified the /userstats/... endpoints, which before were /userstats/user/:username, /userstats/topic/:topic and /userstats/:user/:topic.
Now, there is only one endpoint, /userstats, and it receives query parameters for username, mode and topic. By filtering the user statistics in the database with the query params, we can retrieve any combination of parameters in one line of code.

This is the interface after adding filtering by mode.

![image](https://github.com/user-attachments/assets/72087816-a638-4414-b55a-306e42ca6e11)
![image](https://github.com/user-attachments/assets/3d509850-92f2-4482-b942-17dab64ee29f)